### PR TITLE
Add module alias for MacBookAir7 so it loads automatically

### DIFF
--- a/mba6x_bl.c
+++ b/mba6x_bl.c
@@ -406,3 +406,4 @@ MODULE_DESCRIPTION("MacBook Air 6,1 and 6,2 backlight driver");
 MODULE_LICENSE("GPL");
 
 MODULE_ALIAS("dmi:*:pnMacBookAir6*");
+MODULE_ALIAS("dmi:*:pnMacBookAir7*");


### PR DESCRIPTION
Hi Patrik,
I'm successfully using this module on a MacBookAir7,2. This minor patch allows the module to load automatically but I guess we'll have to update the descriptions as well. Let me know and I'll provide another PR for that.

