### PR TITLE
On suspend, the brightness will gradually decrease to zero.

### DIFF
--- a/mba6x_bl.c
+++ b/mba6x_bl.c
@@ -366,14 +366,27 @@ static void platform_shutdown(struct platform_device *dev)
 	lp8550_restore();
 }
 
+static int platform_suspend(struct platform_device *dev, pm_message_t state)
+{
+	int b;
+
+	/* Takes backlight gradually to zero*/
+	for(b = backlight_device->props.brightness; b >= 0 ; b--) {
+		set_brightness(b);
+	}
+
+	return 0;
+}
+
 static struct platform_driver drv = {
 	.probe		= platform_probe,
 	.remove		= platform_remove,
 	.resume		= platform_resume,
+	.suspend 	= platform_suspend,
 	.shutdown	= platform_shutdown,
-	.driver	= {
-		.name = "mba6x_bl",
-		.owner = THIS_MODULE,
+	.driver		= {
+		.name 	= "mba6x_bl",
+		.owner 	= THIS_MODULE,
 	},
 };
 


### PR DESCRIPTION
This is one thing bugging me since I began using linux. On OS X, when you pull the lid down, the back light gradually goes to zero, using this (or any) driver on linux, it didn't happen, so I added a .suspend callback function in the module which does exactly what I want it to.

P.S First GitHub pull request ever, please go easy on me... :sweat_smile: 